### PR TITLE
Docker: MySQL 도커 컴포즈 구성

### DIFF
--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  mysql:
+    image: mysql:8.4
+    container_name: commerce-mysql
+    restart: unless-stopped
+    ports:
+      - "${MYSQL_PORT:-3333}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: "Asia/Seoul"
+    command:
+      - --default-time-zone=+09:00
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_0900_ai_ci
+      - --sql-mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+      - --max_allowed_packet=256M
+    volumes:
+      - commerce_mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+volumes:
+  commerce_mysql_data:


### PR DESCRIPTION
- https://limdaeil.tistory.com/1

# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

도커 컴포즈로 MySQL 8.4를 실행하도록 스크립트를 작성합니다. 
- .env 파일 안에 ID, PW 등 민감한 정보 관리
- 타임존은 Asia/Seoul 로 설정
- 기본적인 Time Zone은 UTC 기준 +09:00으로 한국 시간대로 조정
- 문자셋을 utf8mb4 설정(기본값. 이모지, 한글, 4바이트, 3바이트 호환, 모든 유니코드 완벽 지원)
- 콜레이션 utf8mb4_0900_ai_ci 설정(문자열 비교, 정렬에 악센트 무시, 대소문자 무시)
- SQL 모드 설정( `- --sql-mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION`)
  - 데이터 형식 올바른지 검사 STRICT_TRANS_TABLES
  - 0 나누기 금지 ERROR_FOR_DIVISION_BY_ZERO
  - InnoDB 말고 다른 엔진 금지 NO_ENGINE_SUBSTITUTION
  - 메시지 크기 256MB 상향(기본값 4MB 또는 16MB)해서 큰 데이터 처리에 용이하게 수정


## 🔍 관련 이슈
- Closes #12

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 데이터 지속성을 위한 MySQL 데이터베이스 서비스 구성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->